### PR TITLE
Autofix: Do Not highlight links

### DIFF
--- a/style/base.css
+++ b/style/base.css
@@ -40,3 +40,13 @@
   padding: var(--jp-private-markdownviewer-padding);
   overflow: auto;
 }
+
+/* Updated link styles */
+.myst a {
+  color: var(--jp-content-link-color);
+  text-decoration: underline;
+}
+
+.myst a:hover {
+  color: var(--jp-content-link-color-hover);
+}


### PR DESCRIPTION
I have updated the CSS styles in style/base.css to ensure links are properly highlighted in the MyST rendered content. This should address the issue of links not being highlighted after updating to JupyterLab 4.3.0. 
> [!CAUTION]  
> Disclaimer: This fix was created by Latta AI and you should never merge before you check the correctness of generated code!

---
This bug was fixed for free by Latta AI - https://latta.ai/ourmission