### PR TITLE
Autofix: Scrolling is stucking on the page

### DIFF
--- a/style/base.css
+++ b/style/base.css
@@ -6,10 +6,16 @@
 @import url('app.css');
 @import url('~katex/dist/katex.css');
 
-/* Allow overflow on input areas for myst */
+/* Allow scrolling on input areas for myst */
+.jp-MySTMarkdownCell {
+  overflow-y: auto;
+  max-height: 100%;
+}
+
 .jp-MySTMarkdownCell .jp-InputArea,
 .jp-MySTMarkdownCell .jp-InputArea > .p-Widget {
-  overflow: visible;
+  overflow-y: visible;
+  overflow-x: auto;
 }
 
 .myst p .lm-Widget img {
@@ -18,7 +24,7 @@
 }
 
 .myst .lm-Widget {
-  overflow: inherit;
+  overflow: visible;
 }
 
 .myst .jp-RenderedHTMLCommon > *:last-child {
@@ -27,6 +33,8 @@
 
 .myst .jp-RenderedHTMLCommon {
   padding-right: 0.1em;
+  overflow-y: visible;
+  overflow-x: auto;
 }
 
 .myst .jp-RenderedText {


### PR DESCRIPTION
I've identified the issue causing the scrolling to stick on the page. The problem was in the CSS for the MySTMarkdownCell. I've updated the `style/base.css` file to allow scrolling within the cell content. Here's what I've done:

1. Modified the CSS for `.jp-MySTMarkdownCell` to enable scrolling.
2. Adjusted the overflow property for the input area and its child widgets.
3. Ensured that the rendered content has proper overflow handling.

These changes should resolve the scrolling issue while maintaining the existing functionality. 
> [!CAUTION]  
> Disclaimer: This fix was created by Latta AI and you should never merge before you check the correctness of generated code!

---
This bug was fixed for free by Latta AI - https://latta.ai/ourmission